### PR TITLE
Fixing surface:1002: attempt to call nil

### DIFF
--- a/cobalt-lib/surface
+++ b/cobalt-lib/surface
@@ -938,6 +938,8 @@ function surface.create(width, height, char, backcolor, textcolor)
 	return surf
 end
 
+local create = surface.create -- To fix the bug on line 1004 (previously line 1002 before this change)
+
 function surface.load(path)
 	local lines, f = { }, fs.open(path, "r")
 	for line in f.readLine do


### PR DESCRIPTION
I run into this problem all the time on Impending Doom when I try to load an image. It's fixed on my end, but it would be nice to have it fixed on all distro's of Cobalt.