### PR TITLE
Added the enabled tag to buttons

### DIFF
--- a/cobalt-ui/elements/button.lua
+++ b/cobalt-ui/elements/button.lua
@@ -16,6 +16,7 @@ local button = {
 	autow = "perc:50",
 	wrap = "left",
 	autoh = true,
+	enabled = true,
 }
 button.__index = button
 
@@ -156,7 +157,7 @@ function button:draw()
 end
 
 function button:mousepressed( x, y, button )
-	if self.state == cobalt.state or self.state == "_ALL" and self.visible then
+	if (self.state == cobalt.state or self.state == "_ALL") and self.visible and self.enabled then
 		if button == 1 then
 			local h = self.h
 			if self.h == 1 then h = 0 end


### PR DESCRIPTION
Added the enabled tag to buttons that allows the developer to stop mouse clicks and graphical changes to the button as a result. I'm using this in Ramuthra's Plane to "grey out" buttons where I don't want the button to flash when I click it nor do I want to add additional logic to the mouseclick callback to handle buttons being greyed out.