### PR TITLE
Fixed another bug

### DIFF
--- a/cobalt
+++ b/cobalt
@@ -49,7 +49,7 @@ local function getFile( file, path )
 end
 
 if not fs.isDir( ".err-logs" ) then
-	fs.makeDir( ".err-logs" )
+	pcall(function() fs.makeDir( ".err-logs" ) end)
 end
 
 local args = { ... }


### PR DESCRIPTION
Along the same line as the last bug. This fixes Cobalt crashing if it attempts to create the error log folder when there's not enough space on the computer, it will instead silently fail.